### PR TITLE
chore(android): linters fixes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,7 +65,6 @@ flutter {
 }
 
 dependencies {
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     // Uniffi
     implementation("net.java.dev.jna:jna:5.7.0@aar")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")


### PR DESCRIPTION
fix various warning from editor & linter:
- remove deprecated localbroadcastmanager
- remove unused variables & code
- other linter/warning fixes