### PR TITLE
feat(android): handle failed mycelium gracefully.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <application
         android:label="myceliumflut"
         android:name="${applicationName}"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/kotlin/tech/threefold/mycelium/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/threefold/mycelium/MainActivity.kt
@@ -1,7 +1,10 @@
 package tech.threefold.mycelium
 
 import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.net.VpnService
 import android.os.Bundle
 import android.util.Log
@@ -50,6 +53,15 @@ class MainActivity: FlutterActivity() {
                 }
                 else -> result.notImplemented()
             }
+        }
+    }
+
+    // TunService EVENT receiver
+    private val tunServiceEventReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            // This method is called when the broadcast intent is received
+            // Update the UI based on the received data
+            Log.e(tag, "UNHANDLED TunService Event")
         }
     }
 
@@ -111,6 +123,9 @@ class MainActivity: FlutterActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // ... your initialization code here ...
+        // Register the receiver
+        val filter = IntentFilter(TunService.EVENT_INTENT)
+        registerReceiver(tunServiceEventReceiver, filter)
         Log.e(tag, "onCreate")
     }
 
@@ -153,6 +168,8 @@ class MainActivity: FlutterActivity() {
 
         // Activity is about to be destroyed.
         // Clean up resources (e.g., close database connections, release network resources).
+        // Unregister the receiver
+        unregisterReceiver(tunServiceEventReceiver)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/android/app/src/main/kotlin/tech/threefold/mycelium/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/threefold/mycelium/MainActivity.kt
@@ -64,7 +64,6 @@ class MainActivity: FlutterActivity() {
     private val tunServiceEventReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             channel.invokeMethod("notifyMyceliumFailed","")
-            stopVpn() // to cleanup the state
         }
     }
 
@@ -97,8 +96,6 @@ class MainActivity: FlutterActivity() {
         }
     }
     private fun startVpn(peers: List<String>, secretKey: ByteArray): Boolean {
-        Log.d("tff", "preparing vpn service")
-
         if (checkAskVpnPermission(peers, secretKey) == true) {
             // need to ask for permission, so stop the flow here.
             // permission handler will be handled by onActivityResult function
@@ -109,9 +106,7 @@ class MainActivity: FlutterActivity() {
         intent.action = TunService.ACTION_START
         intent.putExtra("secret_key", secretKey)
         intent.putStringArrayListExtra("peers", ArrayList(peers))
-        val startResult = startService(intent)
-
-        Log.e("tff", "TunService start service result: " + startResult.toString())
+        startService(intent)
 
         return true
     }

--- a/android/app/src/main/kotlin/tech/threefold/mycelium/TunService.kt
+++ b/android/app/src/main/kotlin/tech/threefold/mycelium/TunService.kt
@@ -18,6 +18,7 @@ private const val tag = "[TunService]"
 class TunService : VpnService(), CoroutineScope {
 
     companion object {
+        const val EVENT_INTENT = "tech.threefold.mycelium.TunService.EVENT"
         const val ACTION_START = "tech.threefold.mycelium.TunService.START"
         const val ACTION_STOP = "tech.threefold.mycelium.TunService.STOP"
     }
@@ -103,7 +104,19 @@ class TunService : VpnService(), CoroutineScope {
         launch {
             // TODO: detect if startMycelium failed and handle it
             // how?
-            startMycelium(peers, parcel.fd, secretKey)
+            try {
+                startMycelium(peers, parcel.fd, secretKey)
+                if (started.get() == true) {
+                    Log.e(tag, "mycelium unexpectedly finished")
+                    sendBroadcast(Intent(EVENT_INTENT))
+                } else {
+                    Log.i(tag, "mycelium finished cleanly")
+                }
+
+            } catch (e: Exception) {
+                Log.e(tag, "startMycelium failed with exception", e)
+                // Handle the error here
+            }
         }
 
         return parcel.fd

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,13 @@ final _logger = Logger('Mycelium');
 const String startMyceliumText = 'Start Mycelium';
 const String stopMyceliumText = 'Stop Mycelium';
 
+const String myceliumStatusStarted = 'Mycelium Started';
+const String myceliumStatusStopped = 'Mycelium Stopped';
+const String myceliumStatusFailedStart = 'Mycelium failed to start';
+const Color myceliumStatusBackgroundColorStarted = Colors.lightGreenAccent;
+const Color myceliumStatusBackgroundColorStopped = Colors.grey;
+const Color myceliumStatusBackgroundColorFailedStart = Colors.yellowAccent;
+
 Future<void> main() async {
   // Logger configuration
   Logger.root.level = Level.ALL; // Log messages emitted at all levels
@@ -48,6 +55,9 @@ class _MyAppState extends State<MyApp> {
           setState(() {
             _isStarted = false;
             _textButton = startMyceliumText;
+            _myceliumStatus = myceliumStatusFailedStart;
+            _myceliumStatusBackgroundColor =
+                myceliumStatusBackgroundColorFailedStart;
           });
 
           break;
@@ -79,6 +89,8 @@ class _MyAppState extends State<MyApp> {
   // start/stop mycelium button variables
   bool _isStarted = false;
   String _textButton = startMyceliumText;
+  String _myceliumStatus = '';
+  Color _myceliumStatusBackgroundColor = Colors.white;
 
   // peers text field
   final textEditController =
@@ -101,7 +113,7 @@ class _MyAppState extends State<MyApp> {
         body: Center(
           child: Column(
             children: [
-              Text('node_addr:$_nodeAddr\n'),
+              SelectableText(_nodeAddr),
               TextField(
                 controller: textEditController,
                 minLines: 2,
@@ -122,9 +134,13 @@ class _MyAppState extends State<MyApp> {
                       setState(() {
                         _isStarted = true;
                         _textButton = stopMyceliumText;
+                        _myceliumStatus = myceliumStatusStarted;
+                        _myceliumStatusBackgroundColor =
+                            myceliumStatusBackgroundColorStarted;
                       });
                     } on PlatformException {
                       _logger.warning("Start VPN failed");
+                      _myceliumStatus = myceliumStatusFailedStart;
                     }
                   } else {
                     try {
@@ -132,6 +148,9 @@ class _MyAppState extends State<MyApp> {
                       setState(() {
                         _isStarted = false;
                         _textButton = startMyceliumText;
+                        _myceliumStatus = myceliumStatusStopped;
+                        _myceliumStatusBackgroundColor =
+                            myceliumStatusBackgroundColorStopped;
                       });
                     } on PlatformException {
                       _logger.warning("stopping VPN failed");
@@ -140,6 +159,10 @@ class _MyAppState extends State<MyApp> {
                 },
                 child: Text(_textButton),
               ),
+              const SizedBox(height: 5), // Add some space
+              Container(
+                  color: _myceliumStatusBackgroundColor,
+                  child: Text(_myceliumStatus)),
             ],
           ),
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,9 @@ import 'package:logging/logging.dart';
 
 final _logger = Logger('Mycelium');
 
+const String startMyceliumText = 'Start Mycelium';
+const String stopMyceliumText = 'Stop Mycelium';
+
 Future<void> main() async {
   // Logger configuration
   Logger.root.level = Level.ALL; // Log messages emitted at all levels
@@ -36,6 +39,22 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     initPlatformState();
+    platform.setMethodCallHandler((MethodCall call) async {
+      switch (call.method) {
+        case 'notifyMyceliumFailed':
+          _logger.warning("Mycelium failed to start");
+          // Handle the method call and optionally return a result
+          // Update the UI
+          setState(() {
+            _isStarted = false;
+            _textButton = startMyceliumText;
+          });
+
+          break;
+        default:
+          throw MissingPluginException();
+      }
+    });
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
@@ -59,7 +78,7 @@ class _MyAppState extends State<MyApp> {
 
   // start/stop mycelium button variables
   bool _isStarted = false;
-  String _textButton = "Start Mycelium";
+  String _textButton = startMyceliumText;
 
   // peers text field
   final textEditController =
@@ -102,7 +121,7 @@ class _MyAppState extends State<MyApp> {
                       // TODO: check return value of the startVpn above
                       setState(() {
                         _isStarted = true;
-                        _textButton = "Stop Mycelium";
+                        _textButton = stopMyceliumText;
                       });
                     } on PlatformException {
                       _logger.warning("Start VPN failed");
@@ -112,7 +131,7 @@ class _MyAppState extends State<MyApp> {
                       stopVpn(platform);
                       setState(() {
                         _isStarted = false;
-                        _textButton = "Start Mycelium";
+                        _textButton = startMyceliumText;
                       });
                     } on PlatformException {
                       _logger.warning("stopping VPN failed");


### PR DESCRIPTION
Mycelium is started on separate thread, so it is not straightforward to handle if it is failed.

The plan is to send the failed event from TunService to MainActivity, and then MainActivity will notify Flutter.